### PR TITLE
Fix for missing line endings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,8 @@ fn main() -> io::Result<()> {
     // lock stdout to speed up the writes
     let mut stdout = stdout.lock();
 
+    let eol = [b'\n'];
+
     // sequential readers for now
     for reader in readers {
         // iterate all lines (unsafe is ok due to for-loop syntax)
@@ -72,6 +74,7 @@ fn main() -> io::Result<()> {
                 } else if !options.inverted {
                     // echo if not inverted
                     stdout.write_all(input)?;
+                    stdout.write(&eol)?;
                 }
             } else {
                 // handle stats or print
@@ -81,6 +84,7 @@ fn main() -> io::Result<()> {
                 } else if options.inverted {
                     // echo if we're inverted
                     stdout.write_all(input)?;
+                    stdout.write(&eol)?;
                 }
             }
         }


### PR DESCRIPTION
The bytelines library removes the newline character here:
https://github.com/whitfin/bytelines/blob/master/src/lib.rs#L161

We're putting it back.