### PR TITLE
Fix a few small lint errors

### DIFF
--- a/src/filters.rs
+++ b/src/filters.rs
@@ -126,7 +126,7 @@ impl Filter for DigestFilter {
 ///
 /// Remember that repeatedly running Runiq on the same input would be
 /// a good candidate for sorting your data initially and then making
-/// use of this filter to optimize memory usage going forware.
+/// use of this filter to optimize memory usage going forward.
 #[derive(Clone, Debug)]
 pub struct SortedFilter {
     inner: Vec<u8>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,8 @@ use std::env;
 use std::fs::File;
 use std::io::{self, BufReader, Read, Write};
 
+const EOL: &[u8; 1] = &[b'\n'];
+
 fn main() -> io::Result<()> {
     // parse in our options from the command line args
     let options = Options::from(&mut env::args_os());
@@ -38,7 +40,7 @@ fn main() -> io::Result<()> {
 
     // ensure all sources exist as readers
     let readers: Vec<Box<Read>> = (&options.inputs)
-        .into_iter()
+        .iter()
         .map(|input| -> Box<Read> {
             match input.as_ref() {
                 "-" => Box::new(stdin.lock()),
@@ -55,9 +57,6 @@ fn main() -> io::Result<()> {
 
     // lock stdout to speed up the writes
     let mut stdout = stdout.lock();
-
-    // eol byte slice
-    let eol = &[b'\n'];
 
     // sequential readers for now
     for reader in readers {
@@ -78,7 +77,7 @@ fn main() -> io::Result<()> {
                 } else if !options.inverted {
                     // echo if not inverted
                     stdout.write_all(input)?;
-                    stdout.write_all(eol)?;
+                    stdout.write_all(EOL)?;
                 }
             } else {
                 // handle stats or print
@@ -88,7 +87,7 @@ fn main() -> io::Result<()> {
                 } else if options.inverted {
                     // echo if we're inverted
                     stdout.write_all(input)?;
-                    stdout.write_all(eol)?;
+                    stdout.write_all(EOL)?;
                 }
             }
         }

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -61,12 +61,12 @@ impl Stats {
 
     /// Prints all statistics to stdout.
     pub fn print(&self) {
-        println!("");
+        println!();
         uprintln("Unique Count", self.uniques(), 1);
         uprintln("Total Count", self.total(), 2);
         uprintln("Dup Offset", self.duplicates(), 3);
         println!("Dup Rate:{:>22.2}%", 100.0 - self.rate());
-        println!("");
+        println!();
     }
 }
 


### PR DESCRIPTION
This is a fix for two small clippy lint errors, as well as a small typo in a comment.

It also hoists the `eol` variable from #3 out into a constant.