### PR TITLE
WASIX support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runiq"
-version = "1.2.2" # remember to update html_root_url
+version = "1.2.2"                                                                 # remember to update html_root_url
 authors = ["Isaac Whitfield <iw@whitfin.io>"]
 description = "An efficient way to filter duplicate lines from input, à la uniq."
 repository = "https://github.com/whitfin/runiq"
@@ -19,3 +19,6 @@ clap = { version = "3.1", features = ["derive"] }
 fnv = "1.0"
 scalable_bloom_filter = "0.1"
 twox-hash = "1.6"
+
+[patch.crates-io]
+tokio = { git = "https://github.com/wasix-org/tokio", branch = "wasix-1.24.2" }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # runiq
+
 [![Crates.io](https://img.shields.io/crates/v/runiq.svg)](https://crates.io/crates/runiq) [![Build Status](https://img.shields.io/github/actions/workflow/status/whitfin/runiq/rust.yml)](https://github.com/whitfin/runiq/actions)
 
 This project offers an efficient way (in both time and space) to filter duplicate entries (lines) from texual input. This project was born from [neek](https://github.com/whitfin/neek), but optimized for both speed and memory. Several filtering options are supported depending on your data and tradeoffs you wish to make between speed and memory usage. For a more detailed explanation, see the relevant [blog post](https://whitfin.io/filtering-unique-logs-using-rust/).
@@ -41,14 +42,14 @@ this is another unique line
 
 Here are some comparisons of `runiq` against other methods of filtering uniques:
 
-| Tool  | Flags     | Time Taken     | Peak Memory     |
-|-------|-----------|----------------|-----------------|
-| neek  | N/A       | 55.8s          | 313MB           |
-| sort  | -u        | 595s           | 9.07GB          |
-| uq    | N/A       | 32.3s          | 1.66GB          |
-| runiq | -f digest | **17.8s**      | 64.6MB          |
-| runiq | -f naive  | 26.3s          | 1.62GB          |
-| runiq | -f bloom  | 36.8s          | **13MB**        |
+| Tool  | Flags     | Time Taken | Peak Memory |
+| ----- | --------- | ---------- | ----------- |
+| neek  | N/A       | 55.8s      | 313MB       |
+| sort  | -u        | 595s       | 9.07GB      |
+| uq    | N/A       | 32.3s      | 1.66GB      |
+| runiq | -f digest | **17.8s**  | 64.6MB      |
+| runiq | -f naive  | 26.3s      | 1.62GB      |
+| runiq | -f bloom  | 36.8s      | **13MB**    |
 
 The numbers above are based on filtering unique values out of the following file:
 
@@ -57,4 +58,24 @@ File size:     3,290,971,321 (~3.29GB)
 Line count:        5,784,383
 Unique count:      2,715,727
 Duplicates:        3,068,656
+```
+
+### Usage on WASIX
+
+#### Compile the binary
+
+```shell
+$ cargo wasix build --release
+```
+
+> Note: create a test folder in the `target/wasm32-wasmer-wasi/release/test` and make the `input.txt` file
+
+### running the binary
+
+```
+$ cd target/wasm32-wasmer-wasi/release
+$ wasmer run runiq.wasm --mapdir=/test:test -- test/input.txt
+this is a unique line
+this is a duplicate line
+this is another unique line
 ```


### PR DESCRIPTION
Implemented [WASIX](https://wasix.org/) support for this library.

This library now runs in WASIX and can be distributed as a single file for all platforms that wasmer supports 🚀